### PR TITLE
Show active rules on histogram

### DIFF
--- a/packages/frontend-web/src/app/components/RuleBars/RuleBars.tsx
+++ b/packages/frontend-web/src/app/components/RuleBars/RuleBars.tsx
@@ -83,6 +83,7 @@ function differentiateRules(rules: List<IRuleModel>): Array<IRuleModel> {
 
 export interface IRuleBarsProps {
   rules?: List<IRuleModel>;
+  articleRules?: List<IRuleModel>;
   automatedRuleToast?(rule: IRuleModel): void;
 }
 
@@ -90,9 +91,11 @@ export class RuleBars extends React.Component<IRuleBarsProps> {
   render() {
     const {
       rules,
+      articleRules
     } = this.props;
 
-    const rulesToDisplay = rules && differentiateRules(rules);
+    const activeRules = articleRules && articleRules.size > 0 ? articleRules : rules
+    const rulesToDisplay = activeRules && differentiateRules(activeRules);
 
     return (
       <div {...css(STYLES.wrapper)}>

--- a/packages/frontend-web/src/app/scenes/Comments/components/NewComments/NewComments.tsx
+++ b/packages/frontend-web/src/app/scenes/Comments/components/NewComments/NewComments.tsx
@@ -272,6 +272,7 @@ export interface INewCommentsProps extends WithRouterProps {
   isItemChecked(id: string): boolean;
   tags: List<ITagModel>;
   rules?: List<IRuleModel>;
+  articleRules?: List<IRuleModel>;
   getLinkTarget(comment: ICommentModel): string;
   textSizes?: Map<number, number>;
   tagComments?(ids: Array<string>, tagId: string): any;
@@ -583,6 +584,7 @@ export class NewComments extends React.Component<INewCommentsProps, INewComments
   render() {
     const {
       article,
+      articleRules,
       commentScores,
       textSizes,
       getLinkTarget,
@@ -670,6 +672,8 @@ export class NewComments extends React.Component<INewCommentsProps, INewComments
       tagSelectorLink(categoryBase, this.props.params.categoryId, selectedTag && selectedTag.id);
 
     const rules = selectedTag && selectedTag.key !== 'DATE' && rulesInCategory && List<IRuleModel>(rulesInCategory.filter( r => r.tagId && r.tagId == selectedTag.id));
+    const articleRulesForTag = selectedTag && selectedTag.key !== 'DATE' && List<IRuleModel>(articleRules.filter( r => r.tagId && r.tagId == selectedTag.id));
+
     const disableAllButtons = areNoneSelected || commentScores.size <= 0;
     const groupBy = (selectedTag && selectedTag.key === 'DATE') ? 'date' : 'score';
 
@@ -718,6 +722,7 @@ export class NewComments extends React.Component<INewCommentsProps, INewComments
             <BatchSelector
               groupBy={groupBy}
               rules={rules}
+              articleRules={articleRulesForTag}
               areAutomatedRulesApplied={article && article.isAutoModerated}
               defaultSelectionPosition1={pos1}
               defaultSelectionPosition2={pos2}

--- a/packages/frontend-web/src/app/scenes/Comments/components/NewComments/components/BatchSelector/BatchSelector.tsx
+++ b/packages/frontend-web/src/app/scenes/Comments/components/NewComments/components/BatchSelector/BatchSelector.tsx
@@ -92,6 +92,7 @@ export interface IBatchSelectorProps {
   commentScores: List<ICommentScoredModel | ICommentDatedModel>;
   groupBy: 'date' | 'score';
   rules?: List<IRuleModel>;
+  articleRules?: List<IRuleModel>;
   onSelectionChange?(selectedComments: Array<number>, pos1: number, pos2: number): void;
   onSelectionChangeEnd?(selectedComments: Array<number>, pos1: number, pos2: number): void;
   areAutomatedRulesApplied?: boolean;
@@ -149,6 +150,7 @@ export class BatchSelector
 
     const {
       rules,
+      articleRules,
       automatedRuleToast,
       areAutomatedRulesApplied,
     } = this.props;
@@ -174,6 +176,7 @@ export class BatchSelector
           {rules && rules.size > 0 && areAutomatedRulesApplied && (
             <RuleBars
               rules={rules}
+              articleRules={articleRules}
               automatedRuleToast={automatedRuleToast}
             />
           )}

--- a/packages/frontend-web/src/app/scenes/Comments/components/NewComments/index.ts
+++ b/packages/frontend-web/src/app/scenes/Comments/components/NewComments/index.ts
@@ -14,12 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { Set } from 'immutable';
+import { Set, List } from 'immutable';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import { compose } from 'redux';
 import { createStructuredSelector } from 'reselect';
-import { ICommentModel } from '../../../../../models';
+import { ICommentModel, IRuleModel } from '../../../../../models';
 import { ICommentAction } from '../../../../../types';
 import { IAppDispatch, IAppStateRecord } from '../../../../stores';
 import { getArticle } from '../../../../stores/articles';
@@ -179,6 +179,14 @@ const mapStateToProps = createStructuredSelector({
   },
 
   rules: getRules,
+
+  articleRules: (state: IAppStateRecord, { params }: INewCommentsProps) => {
+    if (params.articleId) {
+      let article = getArticle(state, params.articleId);
+      return  List<IRuleModel>(article.moderationRules)
+    }
+  },
+  
 
   getLinkTarget: (state: IAppStateRecord, { params }: any) => {
     const identifier = getCurrentPagingIdentifier(state);


### PR DESCRIPTION
This updates the histogram to show the active rule bars (selected between article level rules and section rules) rather than always showing the section rules

Here is an example of comments being hidden by showing the section level rule bar instead of the override: 
https://moderator-dashboard.prd.nyt.net/articles/article_100000008527353/new/SUMMARY_SCORE?pos1=0.6&pos2=0.75 