### PR TITLE
Fix defaults for new rule row

### DIFF
--- a/packages/frontend-web/src/app/components/ArticleControls/ArticleControlsMenu.tsx
+++ b/packages/frontend-web/src/app/components/ArticleControls/ArticleControlsMenu.tsx
@@ -119,9 +119,10 @@ export class ArticleControlMenu extends React.Component<IArticleControlMenuProps
       id: (placeholderId--).toString(),
       createdBy: null,
       articleId: this.props.article.id,
-      tagId: "15",
-      lowerThreshold: 0.8,
-      upperThreshold: 1,
+      // Find the id for summary score tag to use as default or otherwise fallback to current prod ID value
+      tagId: `${this.props.tags.find((tag) => { return tag.label==="Summary Score"}).id || 16}`,
+      lowerThreshold: 0,
+      upperThreshold: 0.2,
       action: SERVER_ACTION_ACCEPT,
     });
     const updatedRules = this.props.controlState.moderationRules || [];


### PR DESCRIPTION
Updates the defaults for a new moderation rule created in the article controls to be more sensical.

Now we will default to the Summary Score tag with an accept action on the 0-20% range 